### PR TITLE
Add event for levelling up skill, allow different skill level formulas

### DIFF
--- a/Sleep.cs
+++ b/Sleep.cs
@@ -76,7 +76,7 @@ namespace ProjectCommunity {
         {
             if (DayNightCycle.timeOfDay < nightTime)
             {
-                pl.Message("%cIt's not night time yet!");
+                pl.Message("%cIt is not night time yet!");
                 return;
             }
 

--- a/XPSystem.cs
+++ b/XPSystem.cs
@@ -2,11 +2,12 @@ using System;
 using System.Collections.Generic;
 using MCGalaxy.Events.LevelEvents;
 using MCGalaxy.Events.PlayerEvents;
+using MCGalaxy.Events;
 using MCGalaxy.Maths;
 using MCGalaxy.SQL;
 using MCGalaxy.Tasks;
 using MCGalaxy;
-
+using ProjectCommunity.Events.PlayerEvents;
 namespace ProjectCommunity {
 
     public class XPSkillInfo
@@ -14,7 +15,7 @@ namespace ProjectCommunity {
         public string Colour;
         public virtual int XPRequiredForLevel(int level)
         {
-            return level*100;
+            return (level*100);
         }
         public XPSkillInfo(string colour="%e")
         {
@@ -31,6 +32,7 @@ namespace ProjectCommunity {
         Farming,
         Social
     }
+
     public class XPSystem : Plugin {
         public override string creator { get { return "morgana"; } }
         public override string MCGalaxy_Version { get { return "1.9.5.1"; } }
@@ -150,6 +152,8 @@ namespace ProjectCommunity {
                 .Replace("{lvl}", newlvl.ToString());
 
             p.Message(msg);
+
+            OnPlayerXPLevelUpEvent.Call(p, skill, lvl, newlvl);
         }
 
         public class CmdXP : Command2
@@ -259,5 +263,21 @@ namespace ProjectCommunity {
             }
         }
 
+    }
+}
+
+namespace ProjectCommunity.Events.PlayerEvents {
+    public delegate void OnPlayerXPLevelUp(Player p, XPSkill skill, int oldLevel, int newLevel);
+
+    public sealed class OnPlayerXPLevelUpEvent : IEvent<OnPlayerXPLevelUp> 
+    {      
+        public static void Call(Player p, XPSkill skill, int oldLevel, int newLevel) {
+            IEvent<OnPlayerXPLevelUp>[] items = handlers.Items;
+            for (int i = 0; i < items.Length; i++) 
+            {
+                try { items[i].method(p, skill, oldLevel, newLevel); } 
+                catch (Exception ex) { LogHandlerException(ex, items[i]); }
+            }
+        }
     }
 }

--- a/XPSystem.cs
+++ b/XPSystem.cs
@@ -8,10 +8,11 @@ using MCGalaxy.Tasks;
 using MCGalaxy;
 
 namespace ProjectCommunity {
+
     public class XPSkillInfo
     {
         public string Colour;
-        public int XPRequiredForLevel(int level)
+        public virtual int XPRequiredForLevel(int level)
         {
             return level*100;
         }
@@ -20,6 +21,7 @@ namespace ProjectCommunity {
             this.Colour = colour;
         }
     }
+
     public enum XPSkill
     {
         Fishing,


### PR DESCRIPTION
Can now subscribe to an event for when a player levels up a skill, and define different formulas for different skills if desired 



Rough example for subscribing to level up event, incase you want to give items when they reach a certain level or something like that
```cs
using ProjectCommunity.Events.PlayerEvents;
using ProjectCommunity;
//pluginref xpsystem.dll
```
```cs
public override void Load(bool startup)
{
	OnPlayerXPLevelUpEvent.Register(onlevelup, MCGalaxy.Priority.High);
}
public override void Unload(...)
{
	OnPlayerXPLevelUpEvent.Unregister(onlevelup);
}
```
```cs
void onlevelup(Player p, XPSkill skill, int oldlevel, int newlevel)
{
...
}
```

Rough example for different formulas for different skills (`XPFishingSkillInfo` not actually included in plugin, just an example of what you can do)
```cs
   {XPSkill.Fishing  ,     new XPFishingSkillInfo("%h")},
   {XPSkill.Cooking  ,     new XPSkillInfo("%n")},
```
```cs
    public class XPSkillInfo
    {
        public string Colour;
        public virtual int XPRequiredForLevel(int level)
        {
            return level*100;
        }
        public XPSkillInfo(string colour="%e")
        {
            this.Colour = colour;
        }
    }
    public class XPFishingSkillInfo : XPSkillInfo
    {
        public override int XPRequiredForLevel(int level)
        {
            return level*1000;
        }
        public XPFishingSkillInfo(string colour) : base(colour)
        {
        }
    }
```